### PR TITLE
Removed check for interface, added test with empty methodBody

### DIFF
--- a/kieker-source-instrumentation-library/src/main/java/net/kieker/sourceinstrumentation/instrument/TypeInstrumenter.java
+++ b/kieker-source-instrumentation-library/src/main/java/net/kieker/sourceinstrumentation/instrument/TypeInstrumenter.java
@@ -89,8 +89,7 @@ public class TypeInstrumenter {
          if (child instanceof MethodDeclaration) {
             MethodDeclaration method = (MethodDeclaration) child;
             if (clazz instanceof ClassOrInterfaceDeclaration) {
-               ClassOrInterfaceDeclaration declaringEntity = (ClassOrInterfaceDeclaration) clazz;
-               if (!declaringEntity.isInterface() || method.getBody().isPresent()) {
+               if (method.getBody().isPresent()) {
                   if (configuration.isExtractMethod()) {
                      extractMethod(methodsToAdd, method);
                   }

--- a/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestTypeInstrumentation.java
+++ b/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestTypeInstrumentation.java
@@ -89,6 +89,23 @@ public class TestTypeInstrumentation {
       }
    }
 
+   @Test
+   public void testNoExtractionAndInstrumentationWithEmptyBody() throws IOException {
+      final ClassOrInterfaceDeclaration clazz = setupClazzWithAbstractMethodWithoutBody();
+      final InstrumentationConfiguration configuration = new InstrumentationConfiguration(AllowedKiekerRecord.OPERATIONEXECUTION, false, null, true, true, 0, true);
+      final TypeInstrumenter instrumenter = new TypeInstrumenter(configuration, Mockito.mock(CompilationUnit.class), clazz);
+      Assert.assertTrue(instrumenter.handleTypeDeclaration(clazz, null));
+   }
+
+   private ClassOrInterfaceDeclaration setupClazzWithAbstractMethodWithoutBody() {
+      final ClassOrInterfaceDeclaration clazz = new ClassOrInterfaceDeclaration();
+      clazz.setName("MyClazz");
+      clazz.addMethod("myAbstractMethod", Modifier.Keyword.ABSTRACT);
+      clazz.getMethodsByName("myAbstractMethod").get(0).removeBody();
+      Assert.assertFalse(clazz.getMethodsByName("myAbstractMethod").get(0).getBody().isPresent());
+      return clazz;
+   }
+
    private ClassOrInterfaceDeclaration buildClass() {
 
       ClassOrInterfaceDeclaration clazz = new ClassOrInterfaceDeclaration();


### PR DESCRIPTION
If method had no body but containing class was no interface, check `if (!declaringEntity.isInterface() || method.getBody().isPresent())` did not evaluate second condition which led to an error.
I used other tests in `TestTypeInstrumentation.java` as template which use Javaparser also. Maybe all these tests should be refactored to use regular java files in resources.