### PR TITLE
Android RCA strictmode fix

### DIFF
--- a/kieker-source-instrumentation-library/src/main/java/net/kieker/sourceinstrumentation/instrument/TypeInstrumenter.java
+++ b/kieker-source-instrumentation-library/src/main/java/net/kieker/sourceinstrumentation/instrument/TypeInstrumenter.java
@@ -17,7 +17,6 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.EnumDeclaration;
-import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.AnnotationExpr;
@@ -25,7 +24,6 @@ import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.ast.stmt.BlockStmt;
 import com.github.javaparser.ast.stmt.ExpressionStmt;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 import net.kieker.sourceinstrumentation.InstrumentationConfiguration;
 import net.kieker.sourceinstrumentation.InstrumentationConstants;
@@ -76,20 +74,12 @@ public class TypeInstrumenter {
                   } else {
                      addFields(type, type);
                   }
-                  if (configuration.isStrictMode()) {
-                     addAndroidStrictMode(type);
-                  }
                } else {
                   ClassOrInterfaceDeclaration kiekerValueSubclazz = getValueSubclass(type);
                   addFields(kiekerValueSubclazz, type);
                }
             } else {
                addFields(type, type);
-               if (type instanceof ClassOrInterfaceDeclaration) {
-                  if (configuration.isStrictMode()) {
-                     addAndroidStrictMode(type);
-                  }
-               }
             }
 
             return true;
@@ -129,26 +119,6 @@ public class TypeInstrumenter {
       }
    }
 
-   private void addAndroidStrictMode(TypeDeclaration<?> type) {
-      ClassOrInterfaceDeclaration declaration = (ClassOrInterfaceDeclaration) type;
-      if (isExtendedWith(declaration, "Application")) {
-         BlockStmt staticInitializer = new BlockStmt();
-         staticInitializer.addStatement("android.os.StrictMode.ThreadPolicy policy = new android.os.StrictMode.ThreadPolicy.Builder().permitAll().build();");
-         staticInitializer.addStatement("android.os.StrictMode.setThreadPolicy(policy);");
-         InitializerDeclaration staticInitializerDeclaration = new InitializerDeclaration(true, staticInitializer);
-         type.getMembers().addFirst(staticInitializerDeclaration);
-      }
-   }
-
-   private Boolean isExtendedWith(ClassOrInterfaceDeclaration clazz, String extendsName) {
-      for (ClassOrInterfaceType type : clazz.getExtendedTypes()) {
-         if (type.getNameAsString().equals(extendsName)) {
-            return true;
-         }
-      }
-      return false;
-   }
-   
    private boolean handleChildren(final TypeDeclaration<?> clazz, final String name) {
       List<MethodDeclaration> methodsToAdd = new LinkedList<>();
       boolean constructorFound = false;

--- a/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestScrictMode.java
+++ b/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestScrictMode.java
@@ -3,6 +3,7 @@ package net.kieker.sourceinstrumentation;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.MatcherAssert;
@@ -42,22 +43,47 @@ public class TestScrictMode {
       
       String changedSource = executeInstrumentation(configuration, C0_0, C0_0_FQN);
       MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("android.os.StrictMode.setThreadPolicy(policy);")));
+
+      changedSource = executeInstrumentation(configuration, C1_0, C1_0_FQN);
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("android.os.StrictMode.setThreadPolicy(policy);")));
+   }
+
+   @Test
+   public void testStrictModeNotInstrumented() throws IOException {
+      HashSet<String> includePattern = new HashSet<String>();
+      includePattern.add("void com.my.package.notMatching()");
+      InstrumentationConfiguration configuration = getConfiguration(true, includePattern);
+      
+      String changedSource = executeInstrumentation(configuration, C1_0, C1_0_FQN, false);
+      // TestSourceInstrumentation.testFileIsNotInstrumented(changedSource, changedSource, changedSource);
+      MatcherAssert.assertThat(changedSource, Matchers.containsString("android.os.StrictMode.setThreadPolicy(policy);"));
    }
 
    private String executeInstrumentation(InstrumentationConfiguration configuration, String name, String fqn) throws IOException {
+      return executeInstrumentation(configuration, name, fqn, true);
+   }
+
+   private String executeInstrumentation(InstrumentationConfiguration configuration, String name, String fqn, Boolean isInstrumented) throws IOException {
       TestConstants.CURRENT_FOLDER.mkdirs();
 
       File testFile = SourceInstrumentationTestUtil.copyResource(name, PROJECT);
 
       InstrumentKiekerSource instrumenter = new InstrumentKiekerSource(configuration);
       instrumenter.instrument(testFile);
-
-      TestSourceInstrumentation.testFileIsInstrumented(testFile, fqn, "DurationRecord");
+      if (isInstrumented) {
+         TestSourceInstrumentation.testFileIsInstrumented(testFile, fqn, "DurationRecord");
+      } else {
+         TestSourceInstrumentation.testFileIsNotInstrumented(testFile, fqn, "DurationRecord");
+      }
       String changedSource = FileUtils.readFileToString(testFile, StandardCharsets.UTF_8);
       return changedSource;
    }
 
    private InstrumentationConfiguration getConfiguration(boolean strictMode) {
-      return new InstrumentationConfiguration(AllowedKiekerRecord.DURATION, true, true, false, null, null, true, 1000, false, strictMode);
+      return getConfiguration(strictMode, null);
+   }
+
+   private InstrumentationConfiguration getConfiguration(boolean strictMode, HashSet<String> includePattern) {
+      return new InstrumentationConfiguration(AllowedKiekerRecord.DURATION, true, true, false, includePattern, null, true, 1000, false, strictMode);
    }
 }

--- a/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestSourceInstrumentation.java
+++ b/kieker-source-instrumentation-library/src/test/java/net/kieker/sourceinstrumentation/TestSourceInstrumentation.java
@@ -76,6 +76,17 @@ public class TestSourceInstrumentation {
       MatcherAssert.assertThat(changedSource, Matchers.containsString("new " + recordName));
    }
 
+   public static void testFileIsNotInstrumented(final File testFile, final String fqn, final String recordName) throws IOException {
+      String changedSource = FileUtils.readFileToString(testFile, StandardCharsets.UTF_8);
+
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("import kieker.monitoring.core.controller.MonitoringController;")));
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("import kieker.monitoring.core.registry.ControlFlowRegistry;")));
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("import kieker.monitoring.core.registry.SessionRegistry;")));
+
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("signature = \"" + fqn)));
+      MatcherAssert.assertThat(changedSource, Matchers.not(Matchers.containsString("new " + recordName)));
+   }
+
    @Test
    public void testInnerConstructor() throws IOException {
       SourceInstrumentationTestUtil.initSimpleProject("/example_instanceInnerClass/");


### PR DESCRIPTION
This PR solves another problem of this issue https://github.com/jenkinsci/peass-ci-plugin/issues/221.

When RCA is used, at some point only files where a change is determined will be instrumented.
But the class which extends `Application` will always be called and network operation on main thread needs to be permitted, 
because `MonitoringController` is using some methods to access networking related functions. 
This will cause an `android.os.NetworkOnMainThreadException`.

Now if `strictMode` is used, the `StrictMode.ThreadPolicy` block statement will always be inserted into the class that extends "Application".